### PR TITLE
fix error in spanish translation

### DIFF
--- a/values-es/strings.xml
+++ b/values-es/strings.xml
@@ -573,7 +573,7 @@
     <string name="influence_pollution_text">Nadie quiere vivir en un área contaminada.</string>
     <string name="influence_religion_text">La religión aumenta el atributo de los habitantes.</string>
     <string name="influence_sport_text">Mantiene a los habitantes sanos.</string>
-    <string name="draftselector_cmdShow">Espectáculo</string>
+    <string name="draftselector_cmdShow">Ver</string>
     <string name="ca_education_low_text">Educación básica: %1$,d/%2$,d estudiantes</string>
     <string name="ca_education_high_text">Educación superior: %1$,d/%2$,d estudiantes</string>
     <string name="ca_health_text">Cuidado de la salud: %1$,d/%2$,d pacientes</string>
@@ -606,7 +606,7 @@
     <string name="draft_mayorvilla00_text">Una bonita residencia para el alcalde.</string>
     <string name="happiness_health">Salud</string>
     <string name="happiness_firedanger">Peligro de incendio</string>
-    <string name="dialog_screenshot_show">Espectáculo</string>
+    <string name="dialog_screenshot_show">Ver</string>
     <string name="draft_townhall01_title">Ayuntamiento</string>
     <string name="draft_townhall01_text">Un Ayuntamiento que se adapta a la ciudad.</string>
     <string name="loadcity_errordialog_cmdrecover">Recuperar</string>


### PR DESCRIPTION
This PR fixes an error in the Spanish translation file where 'Show' is translated to 'Espectáculo' (from an event) instead of 'Ver' (action for 'view')