### PR TITLE
한글 번역 업데이트 / Korean translation Update

### DIFF
--- a/values-ko/strings.xml
+++ b/values-ko/strings.xml
@@ -2756,7 +2756,7 @@
     <string name="draft_dsaicbmpad_text">DSA 역대 최대 규모의 대륙간 탄도 미사일을 위한 미사일 발사 사일로입니다.</string>
     <string name="draft_dsa_dsaicbmpad_req2_text">도시당 한개만 건설 가능</string>
     <string name="draft_dsacontainmentfacility_title">격리 시설</string>
-    <string name="draft_dsacontainmentfacility_text">악명 높은 포콜로바이러스를 포함하여 인간에게 알려진 가장 위험한 물질을 포함하는 BSL-4 격리 시설입니다.</string>
+    <string name="draft_dsacontainmentfacility_text">악명 높은 포콜로바이러스를 포함하여 인간에게 알려진 가장 위험한 물질을 수용하는 BSL-4 격리 시설입니다.</string>
     <string name="draft_dsawalls_title">오염 방벽</string>
     <string name="draft_dsawalls_text">시민들을 소음과 오염으로부터 지켜줍니다.</string>
     <string name="draft_dsacontainingwalls_title">격리 방벽</string>

--- a/values-ko/strings.xml
+++ b/values-ko/strings.xml
@@ -2323,7 +2323,7 @@
     <string name="draft_woodenpier00_title">목제 부두</string>
     <string name="draft_cobblestones00_title">조약돌</string>
     <string name="draft_fancylongtiles00_title">화려한 긴 타일</string>
-    <string name="draft_finemarble00_title">Fine marble</string>
+    <string name="draft_finemarble00_title">고급 대리석</string>
     <string name="settings_nightmode">야간모드</string>
     <string name="settings_nightmode_day">낮</string>
     <string name="settings_nightmode_night">밤</string>
@@ -2613,7 +2613,7 @@
     <string name="ci_energy_help">많은 건물이 기능하려면 전력이 필요합니다. 충분한 양의 에너지를 생산하고 모든 것이 전력망에 연결되어 있는지 확인하세요.</string>
     <string name="ci_info_help">여기서는 당신의 도시에 대한 몇 가지 일반적인 정보를 볼 수 있습니다.</string>
     <string name="ci_education_help">교육은 주민들의 생활 조건을 개선하는 동시에 교육받은 근로자와 투자자를 유치하는 데 필수적입니다.</string>
-    <string name="ci_airport_help">이것은 본질적으로 공항을 통제하는 항공 교통 관제탑입니다. 지도에서 노선을 선택하고, 비행기를 구입하고, 비행기를 노선에 할당할 수 있습니다.</string>
+    <string name="ci_airport_help">이곳은 본질적으로 공항을 통제하는 항공 교통 관제탑입니다. 지도에서 노선을 선택하고, 비행기를 구입하고, 비행기를 노선에 할당할 수 있습니다.</string>
     <string name="ci_water_help">물은 생명에게 필수적이며 주민들도 예외는 아닙니다. 충분한 양의 물을 공급하고 모든 것이 파이프로 연결되어 있는지 확인하세요. 오염된 지역에는 물 펌프를 설치하지 마세요. 주민들이 병에 걸릴 수 있습니다.</string>
     <string name="ci_statistics_help">이 그래프는 도시의 개발을 추적하는 데 도움이 될 수 있습니다. 다른 그래프 사이를 전환하려면 오른쪽에 있는 화살표를 사용하세요. +/- 버튼을 사용하여 확대 및 축소할 수 있습니다.</string>
 

--- a/values-ko/strings.xml
+++ b/values-ko/strings.xml
@@ -1406,7 +1406,7 @@
     <string name="busgame_route">경로</string>
     <string name="busgame_speed">속력</string>
     <string name="busgame_speed_unit">m/s</string>
-    <string name="busgame_capacity">수용량</string>
+    <string name="busgame_capacity">량</string>
     <string name="busgame_capacity_unit">pl</string>
     <string name="busgame_income">수입</string>
     <string name="busgame_currency">토큰</string>
@@ -2726,7 +2726,7 @@
     <string name="draft_ICBMarm_text">이것을 누르면 대륙간 탄도 미사일이 무장됩니다.</string>
     <string name="draft_dsa_icbm_req_text">무장된 ICBM이 필요합니다</string>
     <string name="draft_prison00_title">감옥</string>
-    <string name="draft_prison00_text">온갖 악행을 저지른 자들을 수용하는 가혹한 장소입니다.</string>
+    <string name="draft_prison00_text">온갖 악행을 저지른 자들을 하는 가혹한 장소입니다.</string>
     <string name="draft_prison_upgrade00_title">읽고쓰기 프로그램</string>
     <string name="draft_prison_upgrade00_text">수감자들에게 다시 범죄자가 될 가능성을 낮추는 기본 사항을 가르치십시오.</string>
     <string name="draft_dsacommand_requirement">필요: DSA 본부</string>
@@ -2756,7 +2756,7 @@
     <string name="draft_dsaicbmpad_text">DSA 역대 최대 규모의 대륙간 탄도 미사일을 위한 미사일 발사 사일로입니다.</string>
     <string name="draft_dsa_dsaicbmpad_req2_text">도시당 한개만 건설 가능</string>
     <string name="draft_dsacontainmentfacility_title">격리 시설</string>
-    <string name="draft_dsacontainmentfacility_text">악명 높은 포콜로바이러스를 포함하여 인간에게 알려진 가장 위험한 물질을 수용하는 BSL-4 격리 시설입니다.</string>
+    <string name="draft_dsacontainmentfacility_text">악명 높은 포콜로바이러스를 포함하여 인간에게 알려진 가장 위험한 물질들을 수용하는 BSL-4 격리 시설입니다.</string>
     <string name="draft_dsawalls_title">오염 방벽</string>
     <string name="draft_dsawalls_text">시민들을 소음과 오염으로부터 지켜줍니다.</string>
     <string name="draft_dsacontainingwalls_title">격리 방벽</string>

--- a/values-ko/strings.xml
+++ b/values-ko/strings.xml
@@ -2225,7 +2225,7 @@
     <string name="store_local_plugins">로컬 플러그인</string>
     <string name="dialog_missingplugins_localpluginby">•%1$s by %2$s (로컬 플러그인)</string>
 
-    <string name="dialog_storedisclaimer_title">There\'s more...</string>
+    <string name="dialog_storedisclaimer_title">더 있습니다...</string>
     <string name="dialog_storedisclaimer_text">플러그인 스토어에 오신것을 환영합니다! \n여기서 전세계의 이용자가 만든 수백개의 테오타운 추가 컨텐츠를 이용할 수 있습니다.
 \n
     저희는 다운로드 하기전 플러그인이 무엇을 하는지 플러그인 설명을 신중히 읽어보시길 권합니다.</string>
@@ -2482,10 +2482,10 @@
     <string name="topic_birthday_ja">생일 축하해요 JustAnyone!</string>
 
 
-    <string name="ci_neighbor_se">SE</string>
-    <string name="ci_neighbor_ne">NE</string>
-    <string name="ci_neighbor_nw">NW</string>
-    <string name="ci_neighbor_sw">SW</string>
+    <string name="ci_neighbor_se">남동</string>
+    <string name="ci_neighbor_ne">북동</string>
+    <string name="ci_neighbor_nw">북서</string>
+    <string name="ci_neighbor_sw">남서</string>
     <string name="dialog_removewithprice_title">철거 비용</string>
     <string name="dialog_removewithprice_text">선택 범위의 철거 비용은 %1$s 입니다. 진행하시겠습니까?Do you want to proceed?</string>
 
@@ -2522,7 +2522,7 @@
     <string name="stage_files_createfolder_cmdcreate">만들기</string>
     <string name="stage_files_createfoldercollision_title">폴더가 존재합니다</string>
     <string name="stage_files_createfoldercollision_text">%1$s의 이름을 가진 폴더가 이미 존재합니다!</string>
-    <string name="tool_terrain_smoothwaterheights">Smooth depth</string>
+    <string name="tool_terrain_smoothwaterheights">부드러운 깊이</string>
 
 
     <string name="stage_files_importherefiles">File(s)</string>
@@ -2683,7 +2683,7 @@
     <string name="draft_dsa_outpost00_title">DSA 사무소</string>
     <string name="draft_dsa_outpost00_text">가장 자격을 갖춘 담당자가 있는 지역 DSA 사무소.</string>
     <string name="draft_tool_disaster_super_nuke00_title">„X-treme“ ICBM</string>
-    <string name="draft_tool_disaster_super_nuke00_text">이 DSA의 가장 강력한 ICBM은 접촉하는 모든 것을 파괴할 수 있습니다.</string>
+    <string name="draft_tool_disaster_super_nuke00_text">이 DSA의 가장 강력한 대륙간 탄도 미사일은 접촉하는 모든 것을 파괴할 수 있습니다.</string>
     <string name="draft_tool_disaster_super_nuke00_cmd">테스트해 봅시다!</string>
     <string name="draft_dsa_icbm_marker_title">ICBM 플레어</string>
     <string name="draft_dsa_icbm_marker_text">„X-treme“ ICBM의 목표물 표시를 위한 플레어.</string>
@@ -2723,7 +2723,7 @@
     <string name="draft_dsa_ja_mansion_template00_title">치즈</string>
     <string name="draft_dsa_ja_mansion_template00_text">DSA의 CEO를 위해 만들어진 세계 정상급 치즈.</string>
     <string name="draft_ICBMarm_title">„X-treme“ 무장</string>
-    <string name="draft_ICBMarm_text">이것을 누르면 대륙간탄도미사일이 무장됩니다.</string>
+    <string name="draft_ICBMarm_text">이것을 누르면 대륙간 탄도 미사일이 무장됩니다.</string>
     <string name="draft_dsa_icbm_req_text">무장된 ICBM이 필요합니다</string>
     <string name="draft_prison00_title">감옥</string>
     <string name="draft_prison00_text">온갖 악행을 저지른 자들을 수용하는 가혹한 장소입니다.</string>
@@ -2902,7 +2902,7 @@
     <string name="draft_picklebparty00_opentext02_text">날 여기서 꺼내줘</string>
     <string name="draft_picklebparty00_opentext03_text">어서 해봐...</string>
     <string name="draft_picklebparty00_opentext04_text">난 갇혔어</string>
-    <string name="draft_ranoutofmoney_notify00">아무래도 돈을 전부 써버리신것 같네요! 이 프로젝트에 할당된 마지막 남은 자금을 보내드리고 있습니다. 현명하게 사용하세요!</string>
+    <string name="draft_ranoutofmoney_notify00">아무래도 돈을 전부 써버리신것 같군요! 이 프로젝트에 할당된 마지막 남은 자금을 보내드리고 있습니다. 현명하게 사용하세요!</string>
     <string name="draft_moon_artifact_upgrade00_title">유물 조사하기</string>
     <string name="draft_moon_artifact_upgrade00_text">유물을 조사하고 수집한 자료를 본부로 보내 금전적 보상을 받으세요.</string>
     <string name="draft_space_tree00_title">사이버 나무</string>
@@ -2999,7 +2999,7 @@
     <string name="draft_ground_asphalt00_title">아스팔트</string>
     <string name="draft_ground_asphalt00_text">자동차와 다른 이동수단을 위한 완벽한 지면.</string>
     <string name="draft_ground_concrete00_title">콘크리트</string>
-    <string name="draft_ground_concrete00_text">건강한 양의 콘크리토시스.</string>
+    <string name="draft_ground_concrete00_text">모래하고 비율을 잘 맞추세요.</string>
     <string name="draft_ground_sandstone00_title">사암</string>
     <string name="draft_ground_sandstone00_text">맑은 사암 블록 표면.</string>
     <string name="draft_ground_dirt00_title">흙</string>

--- a/values-ko/strings.xml
+++ b/values-ko/strings.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?><resources>
-    <string name="app_name">TheoTown</string>
+    <string name="app_name">테오타운</string>
     <string name="settings_title">설정</string>
     <string name="loadcity_title">도시 불러오기</string>
     <string name="createcity_title">도시 새로만들기</string>


### PR DESCRIPTION
1 ㅡ 영어 이름을 공식 한국어 명칭 "테오타운"으로 번역.
2228 ㅡ 플러그인 최초 입장 팝업 타이틀 번역.
2326 ㅡ 고급 대리석 번역.
2485~2488 ㅡ 동서남북 방향 번역.
2525 ㅡ Smooth Depth를 부드러운 깊이로 번역하였습니다. 더 자연스러운 번역이 가능할 경우 수정 바람.
2616 ㅡ 본문이 관제탑 건물이 아닌 도움말 텍스트임을 확인하였습니다. 이것 > 이곳.
3002 ㅡ 의역을 하였습니다: 직역시 "건강한 양의 콘크리토시스", 의역으로 영화 짝패를 패러디함.
공통 ㅡ 설명에 쓰인 ICBM은 번역하여 대륙간 탄도 미사일로 풀어 씀.