### PR TITLE
Fixed typing mistake

### DIFF
--- a/values-it/strings.xml
+++ b/values-it/strings.xml
@@ -853,7 +853,7 @@
     <string name="statistics_money">Bilancio</string>
     <string name="statistics_buildings">Edifici</string>
     <string name="statistics_roads">Strade</string>
-    <string name="statistics_rails">Rotraie</string>
+    <string name="statistics_rails">Rotaie</string>
     <string name="statistics_cars">Macchine</string>
     <string name="control_auto">Auto</string>
     <string name="control_on">Su</string>


### PR DESCRIPTION
Just fixed a typing mistake (Rotraie --> Rotaie) in the Italian translation.