### PR TITLE
Update russian translation.xml

### DIFF
--- a/values-ru/strings.xml
+++ b/values-ru/strings.xml
@@ -439,7 +439,7 @@
 <string name="draft_terrainland_text">Размести землю на карте.</string>
 <string name="draft_terrainland_title">Земля</string>
 <string name="draft_terrainwater_text">Размести воду на карте.</string>
-<string name="draft_terrainwater_title">Водоснабжение</string>
+<string name="draft_terrainwater_title">Вода</string>
 <string name="draft_townhall00_text">Большим городам нужна городская ратуша. Жителям понравится.</string>
 <string name="draft_townhall00_title">Городская ратуша</string>
 <string name="draft_townhall01_text">Ратуша может быть построена в твоем городе.</string>


### PR DESCRIPTION
For some reason, the water tile in the Russian translation is called "Водоснабжение"/“Water supply” instead of “Вода”/"Water”